### PR TITLE
typo: correctly flex the auxiliary verb do

### DIFF
--- a/postgresapi/plans.py
+++ b/postgresapi/plans.py
@@ -11,7 +11,7 @@ plans = [
 
 class PlanDoNotExists(Exception):
     def __init__(self, name):
-        self.args = ["Plan %s do not exists." % name]
+        self.args = ["Plan %s does not exist." % name]
 
 def list_active():
     plans_environ = os.environ.get("POSTGRES_API_PLANS", "[]")


### PR DESCRIPTION
For she/he/it subjects, the auxiliary verb _do_ in the present tense is written as recommended in this pull request, _does_.
